### PR TITLE
Added example of list positive and negative sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ fn main() {
 
 Positive and negative sections also apply to lists and maps. An empty list or map means a negative section and a non-empty one represents a positive section.
 
+List:
 
 #### Input
 
@@ -287,11 +288,9 @@ Positive and negative sections also apply to lists and maps. An empty list or ma
 {{+vacation}}
 <h1>Currenty on vacation</h1>
 <ul>
-{{/vacation}}
-{{*vacation}}
+{{*.}}
 <li>{{.}}</li>
-{{/vacation}}
-{{+vacation}}
+{{/.}}
 </ul>
 {{/vacation}}
 {{-vacation}}
@@ -329,6 +328,51 @@ Positive and negative sections also apply to lists and maps. An empty list or ma
 <li>Homer</li>
 <li>Marge</li>
 </ul>
+```
+
+Map:
+
+#### Input
+
+```html
+
+{{+user}}
+<p>Welcome {{last_name}}, {{first_name}}</h1>
+{{/user}}
+{{-user}}
+<p>Create account?</p>
+{{/user}}
+```
+
+#### Data 1
+
+```json
+{
+    "user" : {}
+}
+```
+
+#### Output 1
+
+```html
+<p>Create account?</p>
+```
+
+#### Data 2
+
+```json
+{
+    "user" : {
+        "last_name": "Simpson", 
+        "first_name": "Homer"
+    }
+}
+```
+
+#### Output 2
+
+```html
+<p>Welcome Simpson, Homer</h1>
 ```
 
 ### Maps, Lists, and Partials

--- a/README.md
+++ b/README.md
@@ -284,22 +284,26 @@ Positive and negative sections also apply to lists and maps. An empty list or ma
 
 ```html
 
-{{+on_vacation}}
+{{+vacation}}
 <h1>Currenty on vacation</h1>
 <ul>
-{{*on_vacation}}
-    <li>{{.}}</li>
-{{/on_vacation}}
+{{/vacation}}
+{{*vacation}}
+<li>{{.}}</li>
+{{/vacation}}
+{{+vacation}}
 </ul>
-{{/on_vacation}}
-{{-on_vacation}}<p>Nobody is on vacation currently</p>{{/on_vacation}}
+{{/vacation}}
+{{-vacation}}
+<p>Nobody is on vacation currently</p>
+{{/vacation}}
 ```
 
 #### Data 1
 
 ```json
 {
-  "on_vacation": []
+  "vacation": []
 }
 ```
 
@@ -313,7 +317,7 @@ Positive and negative sections also apply to lists and maps. An empty list or ma
 
 ```json
 {
-  "on_vacation": ["Homer", "Marge"]
+  "vacation": ["Homer", "Marge"]
 }
 ```
 
@@ -322,8 +326,8 @@ Positive and negative sections also apply to lists and maps. An empty list or ma
 ```html
 <h1>Currenty on vacation</h1>
 <ul>
-    <li>Homer</li>
-    <li>Marge</li>
+<li>Homer</li>
+<li>Marge</li>
 </ul>
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,56 @@ fn main() {
 </nav>
 ```
 
+Positive and negative sections also apply to lists and maps. An empty list or map means a negative section and a non-empty one represents a positive section.
+
+
+#### Input
+
+```html
+
+{{+on_vacation}}
+<h1>Currenty on vacation</h1>
+<ul>
+{{*on_vacation}}
+    <li>{{.}}</li>
+{{/on_vacation}}
+</ul>
+{{/on_vacation}}
+{{-on_vacation}}<p>Nobody is on vacation currently</p>{{/on_vacation}}
+```
+
+#### Data 1
+
+```json
+{
+  "on_vacation": []
+}
+```
+
+#### Output 1
+
+```html
+<p>Nobody is on vacation currently</p>
+```
+
+#### Data 2
+
+```json
+{
+  "on_vacation": ["Homer", "Marge"]
+}
+```
+
+#### Output 2
+
+```html
+<h1>Currenty on vacation</h1>
+<ul>
+    <li>Homer</li>
+    <li>Marge</li>
+</ul>
+```
+
 ### Maps, Lists, and Partials
 
 #### Input

--- a/spec/readme_test.v
+++ b/spec/readme_test.v
@@ -114,11 +114,9 @@ fn test_list_positive_negative_sections() {
 	{{+vacation}}
 	<h1>Currenty on vacation</h1>
 	<ul>
-	{{/vacation}}
-	{{*vacation}}
+	{{*.}}
 	<li>{{.}}</li>
-	{{/vacation}}
-	{{+vacation}}
+	{{/.}}
 	</ul>
 	{{/vacation}}
 	{{-vacation}}
@@ -145,6 +143,45 @@ fn test_list_positive_negative_sections() {
 		<li>Homer</li>
 		<li>Marge</li>
 		</ul>
+
+		'.trim_indent(),
+	]
+
+	section_template := template.from_strings(input: input)!
+
+	for index, data in data_list {
+		assert section_template.run(data)! == outputs[index]
+	}
+}
+
+fn test_map_positive_negative_sections() {
+	input := '
+	{{+user}}
+	<p>Welcome {{last_name}}, {{first_name}}</h1>
+	{{/user}}
+	{{-user}}
+	<p>Create account?</p>
+	{{/user}}
+	'.trim_indent()
+	data_list := [
+		datamodel.from_json('{
+			"user" : {}
+		}')!,
+		datamodel.from_json('{
+		"user" : {
+		  	"last_name": "Simpson", 
+		  	"first_name": "Homer"
+		}
+		}')!,
+	]
+
+	outputs := [
+		'
+		<p>Create account?</p>
+
+		'.trim_indent(),
+		'
+      <p>Welcome Simpson, Homer</h1>
 
 		'.trim_indent(),
 	]

--- a/spec/readme_test.v
+++ b/spec/readme_test.v
@@ -109,6 +109,53 @@ fn test_boolean_positive_negative_sections() {
 	}
 }
 
+fn test_list_positive_negative_sections() {
+	input := '
+	{{+vacation}}
+	<h1>Currenty on vacation</h1>
+	<ul>
+	{{/vacation}}
+	{{*vacation}}
+	<li>{{.}}</li>
+	{{/vacation}}
+	{{+vacation}}
+	</ul>
+	{{/vacation}}
+	{{-vacation}}
+	<p>Nobody is on vacation currently</p>
+	{{/vacation}}
+	'.trim_indent()
+	data_list := [
+		datamodel.from_json('{
+		  "vacation": []
+		}')!,
+		datamodel.from_json('{
+		  "vacation": ["Homer", "Marge"]
+		}')!,
+	]
+
+	outputs := [
+		'
+		<p>Nobody is on vacation currently</p>
+
+		'.trim_indent(),
+		'
+		<h1>Currenty on vacation</h1>
+		<ul>
+		<li>Homer</li>
+		<li>Marge</li>
+		</ul>
+
+		'.trim_indent(),
+	]
+
+	section_template := template.from_strings(input: input)!
+
+	for index, data in data_list {
+		assert section_template.run(data)! == outputs[index]
+	}
+}
+
 fn test_maps_lists_partials() {
 	input := '
 	<ol>


### PR DESCRIPTION
## Added example of list positive and negative sections

Unfortunately adding an example for map is not very meaningful until it is possible to iterate over maps.

## Boolean emptiness property for arrays 

[#7 ](https://github.com/hungrybluedev/whisker/issues/7)


