### PR TITLE
Make TemplateConfig fields public to avoid "cannot access private field" error

### DIFF
--- a/template/template.v
+++ b/template/template.v
@@ -13,6 +13,7 @@ pub:
 // TemplateConfig is the configuration struct for a template.
 @[params]
 pub struct TemplateConfig {
+pub:
 	input    string            @[required]
 	partials map[string]string = {}
 }


### PR DESCRIPTION
Since V 0.4.6 accessing to private fields [produces an error](https://github.com/vlang/v/pull/21183) e.g.:

```v
 FAIL  [1/4] C:   735.4 ms, R:     0.000 ms /home/ge/Code/whisker/spec/spec_test.v
>> compilation failed:
spec/spec_test.v:21:43: error: cannot access private field `input` on `template.TemplateConfig`
   19 |         for test in suite.tests {
   20 |             println('${suite.name}: ${test.name}')
   21 |             spec_template := template.from_strings(input: test.template, partials: test.partials)!
      |                                                    ~~~~~~~~~~~~~~~~~~~~
   22 |             output := spec_template.run(test.data)!
   23 |             // dump(output)
spec/spec_test.v:21:65: error: cannot access private field `partials` on `template.TemplateConfig`
   19 |         for test in suite.tests {
   20 |             println('${suite.name}: ${test.name}')
   21 |             spec_template := template.from_strings(input: test.template, partials: test.partials)!
      |                                                                          ~~~~~~~~~~~~~~~~~~~~~~~
   22 |             output := spec_template.run(test.data)!
   23 |             // dump(output)

```
this commit fixes it.

## Checklist

- [x] The project compiles with `v .` and `v -prod .`.
- [x] The unit tests are passing with `v test .`
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] There exists a corresponding issue as a Bug Report or a
  Feature Request.
- [ ] (Optional) I have contacted the developers and received
  feedback on the aforementioned issue.
